### PR TITLE
Add support for sed-style anonymous captures with backslashes

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -130,4 +130,9 @@ pub struct App {
     /// Do not preserve Object ACL settings (set all to private)
     #[structopt(long)]
     pub no_preserve_acl: bool,
+
+    /// Do not allow anonymous capture groups i.e. \1, \2 - may be useful when dealing with
+    /// keys containing backslashes
+    #[structopt(long)]
+    pub no_anonymous_groups: bool,
 }


### PR DESCRIPTION
Resolves #11 

Can be disabled with `--no-anonymous-groups` option since it can interfere with backslash behaviour if keys contain backslashes.