### PR TITLE
Skip writing the new key if it exists in the bucket already

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ FLAGS:
         --no-preserve-acl           Do not preserve Object ACL settings (all will be set to private)
         --no-preserve-properties    Do not preserve object properties (saves retrieving per-object details) - using this
                                     flag will remove any encryption
+        --no-overwrite              Do not overwrite existing keys
     -q, --quiet                     Do not print key modifications
     -V, --version                   Prints version information
     -v, --verbose                   Print debug messages

--- a/src/args.rs
+++ b/src/args.rs
@@ -135,4 +135,8 @@ pub struct App {
     /// keys containing backslashes
     #[structopt(long)]
     pub no_anonymous_groups: bool,
+
+    /// Skip keys that would result in an overwrite
+    #[structopt(long)]
+    pub no_overwrite: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,10 @@ async fn handle_key(
         };
         let head_result = client.head_object(head_request).await?;
         if head_result.metadata.is_some() {
-            debug!("Skipping {:?} since this would result in overwriting", newkey);
+            debug!(
+                "Skipping {} since this would result in overwriting", 
+                newkey
+            );
             return Ok(());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,26 +204,23 @@ async fn handle_key(
     }
     if no_overwrite {
         let head_request = HeadObjectRequest {
-                bucket: (*bucket).to_string(),
-                if_match: None,
-                if_modified_since: None,
-                if_none_match: None,
-                if_unmodified_since: None,
-                key: String::from(newkey.to_owned()),
-                part_number: None,
-                range: None,
-                request_payer: None,
-                sse_customer_algorithm: None, // Cannot be empty if using sse-c
-                sse_customer_key: None,
-                sse_customer_key_md5: None,
-                version_id: None,
+            bucket: (*bucket).to_string(),
+            if_match: None,
+            if_modified_since: None,
+            if_none_match: None,
+            if_unmodified_since: None,
+            key: String::from(newkey.to_owned()),
+            part_number: None,
+            range: None,
+            request_payer: None,
+            sse_customer_algorithm: None, // Cannot be empty if using sse-c
+            sse_customer_key: None,
+            sse_customer_key_md5: None,
+            version_id: None,
         };
         let head_result = client.head_object(head_request).await?;
         if head_result.metadata.is_some() {
-            debug!(
-                "Skipping {} since this would result in overwriting", 
-                newkey
-            );
+            debug!("Skipping {} since this would result in overwriting", newkey);
             return Ok(());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,10 +218,12 @@ async fn handle_key(
             sse_customer_key_md5: None,
             version_id: None,
         };
-        let head_result = client.head_object(head_request).await?;
-        if head_result.metadata.is_some() {
-            debug!("Skipping {} since this would result in overwriting", newkey);
-            return Ok(());
+        let head_result = client.head_object(head_request).await;
+        if let Ok(head_result) = head_result {
+            if head_result.metadata.is_some() {
+                debug!("Skipping {} since this would result in overwriting", newkey);
+                return Ok(());
+            }
         }
     }
     info!("Renaming {} to {}", key.0, newkey);


### PR DESCRIPTION
Added the flag, and logic to skip if a successful head_object_request is made to address #8 .

If the new key does not exist it does not appear to be possible to access the head_result, or the status code of the request, and the future does not continue with the renaming for that key. 

Any thoughts on what could help me to debug this?